### PR TITLE
Fix: Set text color to black in extension settings

### DIFF
--- a/style.css
+++ b/style.css
@@ -21,6 +21,7 @@
     padding: 5px;
     border: 1px solid #ccc;
     border-radius: 3px;
+    color: black;
 }
 
 #dm-memory-view {
@@ -28,4 +29,5 @@
     padding: 10px;
     min-height: 100px;
     background-color: #f0f0f0;
+    color: black;
 }


### PR DESCRIPTION
The text in the input fields and the memory view of the Dynamic Memory extension settings was appearing as white on a white/light-grey background, making it unreadable.

This commit explicitly sets `color: black;` in the CSS for these elements to ensure the text is always visible.