### PR TITLE
Fix: Improve pagination logic to handle large messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,31 +114,20 @@ globalThis.dynamicMemoryInterceptor = async function(chat, contextSize, abort, t
 };
 
 function paginate(chat, pageSize) {
-    const pages = [];
-    let currentPage = '';
-    let currentSize = 0;
-
+    let fullText = '';
     for (const message of chat) {
-        const messageText = `${message.name}: ${message.mes}\n`;
-
-        if (currentSize + messageText.length > pageSize && currentSize > 0) {
-            // Try to find a newline to split on
-            let splitIndex = currentPage.lastIndexOf('\n');
-            if (splitIndex === -1) {
-                splitIndex = pageSize;
-            }
-
-            pages.push(currentPage.substring(0, splitIndex));
-            currentPage = currentPage.substring(splitIndex + 1);
-            currentSize = currentPage.length;
-        }
-
-        currentPage += messageText;
-        currentSize += messageText.length;
+        fullText += `${message.name}: ${message.mes}\n`;
     }
 
-    if (currentPage.length > 0) {
-        pages.push(currentPage);
+    if (fullText.length === 0) {
+        return [];
+    }
+
+    const pages = [];
+    let startIndex = 0;
+    while (startIndex < fullText.length) {
+        pages.push(fullText.substring(startIndex, startIndex + pageSize));
+        startIndex += pageSize;
     }
 
     return pages;


### PR DESCRIPTION
The previous `paginate` function could fail silently when a single chat message was larger than the configured `pageSize`. This would lead to an oversized page being sent to the summarizer API, which would reject the request, resulting in the dynamic memory feature not working for very long messages.

This commit replaces the complex pagination logic with a much simpler and more robust implementation. The new function concatenates the entire chat history into a single string and then splits it into fixed-size chunks. This correctly handles all message sizes and prevents API errors caused by oversized pages.